### PR TITLE
🚜 Hassio token was renamed to Supervisor token

### DIFF
--- a/prometheus/rootfs/etc/cont-init.d/prometheus.sh
+++ b/prometheus/rootfs/etc/cont-init.d/prometheus.sh
@@ -3,4 +3,4 @@
 # Home Assistant Community Add-on: Prometheus
 # Configures Prometheus
 # ==============================================================================
-echo "${HASSIO_TOKEN}" > '/run/home-assistant.token'
+echo "${SUPERVISOR_TOKEN}" > '/run/home-assistant.token'


### PR DESCRIPTION
# Proposed Changes

The `HASSIO_TOKEN` has been renamed to `SUPERVISOR_TOKEN`. 
The `HASSIO_TOKEN` is marked deprecated and soon to be dropped.
