### PR TITLE
fix: update Python version pulled by Docker

### DIFF
--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -18,7 +18,7 @@ RUN \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \
     \
     && apk --no-cache add \
-        python3=3.10.5-r0 \
+        python3=3.10.12-r0 \
         py3-idna=3.3-r2 \
         py3-certifi=2021.10.8-r0 \
         py3-chardet=4.0.0-r3 \


### PR DESCRIPTION
3.10.5 seems to generate a conflict.
Updating to 3.10.12 resolves the conflict.

Fixes #60.
