### PR TITLE
Add the remote write feature

### DIFF
--- a/prometheus/DOCS.md
+++ b/prometheus/DOCS.md
@@ -19,7 +19,7 @@ comparison to installing any other Home Assistant add-on.
 
 There are no configuration options for the addon.
 
-To add additional scrape targets you need to create a file per target in /share/prometheus/targets.
+To add additional scrape targets you need to create a file per target in `/share/prometheus/targets`.
 
 Example:
 
@@ -35,6 +35,22 @@ static_configs:
 ```
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
+
+Similarly, to set up remotes for Prometheus `remote_write` feature, you need to create a file per remote in `/share/prometheus/remotes`.
+
+Example to write to a Grafana Cloud Prometheus endpoint:
+
+```yaml
+url: https://prometheus-prod-01-eu-west-0.grafana.net/api/prom/push
+basic_auth:
+  username: <your username>
+  password: <Your API key>
+write_relabel_configs:
+  - target_label: instance
+    replacement: dev-container
+```
+
+The above example also changes the `instance` label to the `dev-container` value.
 
 The job names `home-assistant` and `prometheus` are already defined by default.
 For the `homeassistant` target you must add add the following to

--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -30,7 +30,6 @@ RUN \
     \
     && curl -J -L -o /tmp/prometheus.tar.gz \
         "https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-${ARCH}.tar.gz" \
-    && adduser -s /bin/false -D -H prometheus \
     && cd /tmp \
     && tar -xvf /tmp/prometheus.tar.gz \
     && mkdir -p /etc/prometheus \
@@ -39,7 +38,6 @@ RUN \
     && cp -R prometheus-${PROMETHEUS_VERSION}.linux-${ARCH}/console_libraries/ /etc/prometheus/ \
     && cp -R prometheus-${PROMETHEUS_VERSION}.linux-${ARCH}/consoles/ /etc/prometheus/ \
     && rm -r prometheus-${PROMETHEUS_VERSION}.linux-${ARCH} \
-    && chown -R prometheus:prometheus /etc/prometheus \
     && pip3 install \
         --no-cache-dir \
         --prefer-binary \

--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -18,7 +18,7 @@ RUN \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \
     \
     && apk --no-cache add \
-        python3=3.10.5-r0 \
+        python3=3.10.12-r0 \
         py3-idna=3.3-r2 \
         py3-certifi=2021.10.8-r0 \
         py3-chardet=4.0.0-r3 \

--- a/prometheus/rootfs/etc/services.d/prometheus-configgen/run
+++ b/prometheus/rootfs/etc/services.d/prometheus-configgen/run
@@ -3,11 +3,10 @@ bashio::log.info 'Starting prometheus config generator...'
 
 if ! bashio::fs.directory_exists /share/prometheus/targets; then
   mkdir -p /share/prometheus/targets
-  chown -R prometheus:prometheus /share/prometheus/targets
 fi
 
 cd /opt/prometheus-configgen || bashio::exit.nok \
   "Could not change working directory for prometheus-configgen."
 
 # Run Prometheus
-exec s6-setuidgid prometheus python3 combiner
+exec python3 combiner

--- a/prometheus/rootfs/etc/services.d/prometheus/run
+++ b/prometheus/rootfs/etc/services.d/prometheus/run
@@ -28,18 +28,15 @@ done
 
 if ! bashio::fs.directory_exists /data/prometheus; then
   mkdir -p /data/prometheus
-  chown prometheus:prometheus /data/prometheus
 fi
 
 if ! bashio::fs.directory_exists /share/prometheus/rules; then
   mkdir -p /share/prometheus/rules
-  chown -R prometheus:prometheus /share/prometheus/rules
 fi
 
 if ! bashio::fs.directory_exists /share/prometheus/targets; then
   mkdir -p /share/prometheus/targets
-  chown -R prometheus:prometheus /share/prometheus/targets
 fi
 
 # Run Prometheus
-exec s6-setuidgid prometheus /usr/local/bin/prometheus "${options[@]}"
+exec /usr/local/bin/prometheus "${options[@]}"

--- a/prometheus/rootfs/etc/services.d/prometheus/run
+++ b/prometheus/rootfs/etc/services.d/prometheus/run
@@ -38,5 +38,9 @@ if ! bashio::fs.directory_exists /share/prometheus/targets; then
   mkdir -p /share/prometheus/targets
 fi
 
+if ! bashio::fs.directory_exists /share/prometheus/remotes; then
+  mkdir -p /share/prometheus/remotes
+fi
+
 # Run Prometheus
 exec /usr/local/bin/prometheus "${options[@]}"

--- a/prometheus/rootfs/opt/prometheus-configgen/combiner
+++ b/prometheus/rootfs/opt/prometheus-configgen/combiner
@@ -22,6 +22,11 @@ def generateConfig():
     )
     del data[".scrape_configs_static"]
     del data[".scrape_configs_included"]
+
+    if len(data[".remote_write_included"]) > 0:
+        data["remote_write"] = data[".remote_write_included"]
+
+    del data[".remote_write_included"]
     return yaml.dump(data, default_flow_style=False, default_style="")
 
 
@@ -52,7 +57,7 @@ def writeConfig(config, file):
 
 
 loop = asyncio.get_event_loop()
-paths_to_watch = ["/share/prometheus/targets/"]
+paths_to_watch = ["/share/prometheus/targets/", "/share/prometheus/remotes"]
 
 lock = asyncio.Lock()
 

--- a/prometheus/rootfs/opt/prometheus-configgen/prometheus.template
+++ b/prometheus/rootfs/opt/prometheus-configgen/prometheus.template
@@ -16,7 +16,6 @@ alerting:
 rule_files:
   - "/share/prometheus/rules/*.yaml"
 
-
 .scrape_configs_included: !include targets/*.yaml
 .scrape_configs_static:
   - job_name: 'home-assistant'
@@ -36,3 +35,5 @@ rule_files:
 
     static_configs:
     - targets: ['localhost:9090']
+
+.remote_write_included: !include remotes/*.yaml


### PR DESCRIPTION
# Proposed Changes

This change adds support for remote write destinations.
This feature can be useful in order to forward metrics collected by the Prometheus instance running alongside HA to another Prometheus instance.

## Related Issues

Fixes #51.

Depends on PRs #61 and #62.